### PR TITLE
potential fix for using test_array_backends

### DIFF
--- a/test/dynamics/common.py
+++ b/test/dynamics/common.py
@@ -76,7 +76,7 @@ class QiskitDynamicsTestCase(unittest.TestCase):
         self.assertTrue(np.allclose(A, B, rtol=rtol, atol=atol))
 
 
-class NumpyTestBase(unittest.TestCase):
+class NumpyTestBase(QiskitDynamicsTestCase):
     """Base class for tests working with numpy arrays."""
 
     @classmethod
@@ -93,7 +93,7 @@ class NumpyTestBase(unittest.TestCase):
         return isinstance(a, np.ndarray)
 
 
-class JAXTestBase(unittest.TestCase):
+class JAXTestBase(QiskitDynamicsTestCase):
     """Base class for tests working with JAX arrays."""
 
     @classmethod
@@ -121,7 +121,7 @@ class JAXTestBase(unittest.TestCase):
         return isinstance(a, jnp.ndarray)
 
 
-class ArrayNumpyTestBase(unittest.TestCase):
+class ArrayNumpyTestBase(QiskitDynamicsTestCase):
     """Base class for tests working with qiskit_dynamics Arrays with numpy backend."""
 
     @classmethod
@@ -138,7 +138,7 @@ class ArrayNumpyTestBase(unittest.TestCase):
         return isinstance(a, Array) and a.backend == "numpy"
 
 
-class ArrayJaxTestBase(unittest.TestCase):
+class ArrayJaxTestBase(QiskitDynamicsTestCase):
     """Base class for tests working with qiskit_dynamics Arrays with jax backend."""
 
     @classmethod

--- a/test/dynamics/signals/test_signals.py
+++ b/test/dynamics/signals/test_signals.py
@@ -33,7 +33,7 @@ except ImportError:
 
 
 @partial(test_array_backends, array_libraries=["numpy", "jax", "array_numpy", "array_jax"])
-class TestSignal(QiskitDynamicsTestCase):
+class TestSignal:
     """Tests for Signal object."""
 
     def setUp(self):
@@ -313,7 +313,7 @@ class TestSignal(QiskitDynamicsTestCase):
 
 
 @partial(test_array_backends, array_libraries=["numpy", "jax", "array_numpy", "array_jax"])
-class TestConstant(QiskitDynamicsTestCase):
+class TestConstant:
     """Tests for constant signal object."""
 
     def setUp(self):
@@ -384,7 +384,7 @@ class TestConstant(QiskitDynamicsTestCase):
 
 
 @partial(test_array_backends, array_libraries=["numpy", "jax", "array_numpy", "array_jax"])
-class TestDiscreteSignal(QiskitDynamicsTestCase):
+class TestDiscreteSignal:
     """Tests for DiscreteSignal object."""
 
     def setUp(self):
@@ -520,8 +520,7 @@ class TestDiscreteSignal(QiskitDynamicsTestCase):
         self.assertAllClose(discrete3.samples, [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0])
 
 
-@partial(test_array_backends, array_libraries=["numpy", "jax", "array_numpy", "array_jax"])
-class TestSignalSum(QiskitDynamicsTestCase):
+class TestSignalSum:
     """Test evaluation functions for ``SignalSum``."""
 
     def setUp(self):
@@ -738,7 +737,6 @@ class TestSignalSum(QiskitDynamicsTestCase):
         )
 
 
-@partial(test_array_backends, array_libraries=["numpy", "jax", "array_numpy", "array_jax"])
 class TestDiscreteSignalSum(TestSignalSum):
     """Tests for DiscreteSignalSum."""
 
@@ -768,8 +766,12 @@ class TestDiscreteSignalSum(TestSignalSum):
         self.assertTrue(empty_sum.samples.shape == (1, 0))
 
 
+test_array_backends(TestSignalSum, array_libraries=["numpy", "jax", "array_numpy", "array_jax"])
+test_array_backends(TestDiscreteSignalSum, array_libraries=["numpy", "jax", "array_numpy", "array_jax"])
+
+
 @partial(test_array_backends, array_libraries=["numpy", "jax", "array_numpy", "array_jax"])
-class TestSignalList(QiskitDynamicsTestCase):
+class TestSignalList:
     """Test cases for SignalList class."""
 
     def setUp(self):
@@ -834,7 +836,7 @@ class TestSignalList(QiskitDynamicsTestCase):
 
 
 @partial(test_array_backends, array_libraries=["numpy", "jax", "array_numpy", "array_jax"])
-class TestSignalCollection(QiskitDynamicsTestCase):
+class TestSignalCollection:
     """Test cases for SignalCollection functionality."""
 
     def setUp(self):
@@ -886,7 +888,7 @@ class TestSignalCollection(QiskitDynamicsTestCase):
         self.assertAllClose(sum_val, self.discrete_sig_sum(3.0))
 
 
-class TestSignalsJaxTransformations(QiskitDynamicsTestCase, JAXTestBase):
+class TestSignalsJaxTransformations(JAXTestBase):
     """Test cases for jax transformations of signals."""
 
     def setUp(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


Not sure if this is exactly what we want, but it's an idea that gets the desired tests to run. The changes are:
- The different array base classes have been changed to inherit from `QiskitDynamicsTestCase`.
- When using `test_array_backends` it is no longer necessary to inherit from `QiskitDynamicsTestCase`, as all of the array base classes do so already.
- If you want to subclass test classes and still use `QiskitDynamicsTestCase`, you can write the classes as usual, then call `test_array_backends` directly on the desired classes after all child classes are made, e.g. in
```
test_array_backends(TestSignalSum, array_libraries=["numpy", "jax", "array_numpy", "array_jax"])
test_array_backends(TestDiscreteSignalSum, array_libraries=["numpy", "jax", "array_numpy", "array_jax"])
```
It's not the most elegant - I was trying to find a solution that preserves the ability to use the function as a class decorator, but so far without success.