### PR TITLE
Further signal arraylias fix

### DIFF
--- a/docs/tutorials/optimizing_pulse_sequence.rst
+++ b/docs/tutorials/optimizing_pulse_sequence.rst
@@ -115,8 +115,9 @@ example of one.
 .. jupyter-execute::
 
     from qiskit_dynamics import DiscreteSignal
-    from qiskit_dynamics.array import Array
     from qiskit_dynamics.signals import Convolution
+
+    import jax.numpy as jnp
 
     # define convolution filter
     def gaus(t):
@@ -128,13 +129,12 @@ example of one.
 
     # define function mapping parameters to signals
     def signal_mapping(params):
-        samples = Array(params)
 
         # map samples into [-1, 1]
-        bounded_samples = np.arctan(samples) / (np.pi / 2)
+        bounded_samples = jnp.arctan(params) / (np.pi / 2)
 
         # pad with 0 at beginning
-        padded_samples = np.append(Array([0], dtype=complex), bounded_samples)
+        padded_samples = jnp.append(jnp.array([0], dtype=complex), bounded_samples)
 
         # apply filter
         output_signal = convolution(DiscreteSignal(dt=1., samples=padded_samples))

--- a/docs/userguide/how_to_configure_simulations.rst
+++ b/docs/userguide/how_to_configure_simulations.rst
@@ -246,7 +246,7 @@ further highlight the benefits of the sparse representation.
 
     static_hamiltonian = 2 * np.pi * v * N + np.pi * anharm * N * (N - np.eye(dim))
     drive_hamiltonian = 2 * np.pi * r * (a + adag)
-    drive_signal = Signal(Array(1.), carrier_freq=v)
+    drive_signal = Signal(1., carrier_freq=v)
 
     y0 = np.zeros(dim, dtype=complex)
     y0[1] = 1.
@@ -266,7 +266,7 @@ amplitude, and just-in-time compile it using JAX.
     )
 
     def dense_func(amp):
-        drive_signal = Signal(Array(amp), carrier_freq=v)
+        drive_signal = Signal(amp, carrier_freq=v)
         res = solver.solve(
             t_span=[0., T],
             y0=y0,
@@ -292,7 +292,7 @@ diagonal, but we explicitly highlight the need for this.
                            evaluation_mode='sparse')
 
     def sparse_func(amp):
-        drive_signal = Signal(Array(amp), carrier_freq=v)
+        drive_signal = Signal(amp, carrier_freq=v)
         res = sparse_solver.solve(
             t_span=[0., T],
             y0=y0,

--- a/docs/userguide/how_to_use_jax.rst
+++ b/docs/userguide/how_to_use_jax.rst
@@ -138,7 +138,6 @@ before setting the signals, to ensure the simulation function remains pure.
     def sim_function(amp):
 
         # define a constant signal
-        amp = Array(amp)
         signals = [Signal(amp, carrier_freq=w)]
 
         # simulate and return results

--- a/docs/userguide/how_to_use_pulse_schedule_for_jax_jit.rst
+++ b/docs/userguide/how_to_use_pulse_schedule_for_jax_jit.rst
@@ -137,6 +137,6 @@ JAX-compiled (or more generally, JAX-transformed).
         # convert from a pulse schedule to a list of signals
         converter = InstructionToSignals(dt, carriers={"d0": w})
         
-        return converter.get_signals(schedule)[0].samples.data
+        return converter.get_signals(schedule)[0].samples
 
     jax.jit(jit_func)(0.4)

--- a/docs/userguide/perturbative_solvers.rst
+++ b/docs/userguide/perturbative_solvers.rst
@@ -179,7 +179,7 @@ these functions gives a sense of the speeds attainable by these solvers.
         """For a given envelope amplitude, simulate the final unitary using the
         Dyson solver.
         """
-        drive_signal = Signal(lambda t: Array(amp) * envelope_func(t), carrier_freq=v)
+        drive_signal = Signal(lambda t: amp * envelope_func(t), carrier_freq=v)
         return dyson_solver.solve(
             signals=[drive_signal],
             y0=np.eye(dim, dtype=complex),
@@ -220,7 +220,7 @@ accuracy and simulation speed.
 
     # specify tolerance as an argument to run the simulation at different tolerances
     def ode_sim(amp, tol):
-        drive_signal = Signal(lambda t: Array(amp) * envelope_func(t), carrier_freq=v)
+        drive_signal = Signal(lambda t: amp * envelope_func(t), carrier_freq=v)
         res = solver.solve(
             t_span=[0., int(T // dt) * dt],
             y0=np.eye(dim, dtype=complex),

--- a/qiskit_dynamics/arraylias/alias.py
+++ b/qiskit_dynamics/arraylias/alias.py
@@ -20,6 +20,8 @@ from typing import Union
 
 from arraylias import numpy_alias, scipy_alias
 
+from qiskit import QiskitError
+
 from qiskit_dynamics.array import Array
 
 # global NumPy and SciPy aliases
@@ -35,3 +37,18 @@ DYNAMICS_SCIPY = DYNAMICS_SCIPY_ALIAS()
 
 
 ArrayLike = Union[Union[DYNAMICS_NUMPY_ALIAS.registered_types()], list]
+
+
+def _preferred_lib(*args):
+    if len(args) == 1:
+        return DYNAMICS_NUMPY_ALIAS.infer_libs(args[0])
+    
+    lib0 = DYNAMICS_NUMPY_ALIAS.infer_libs(args[0])[0]
+    lib1 = _preferred_lib(args[1:])[0]
+
+    if lib0 == "numpy" and lib1 == "numpy":
+        return "numpy"
+    elif lib0 == "jax" or lib1 == "jax":
+        return "jax"
+    
+    raise QiskitError("_preferred_lib could not resolve preferred library.")

--- a/qiskit_dynamics/models/operator_collections.py
+++ b/qiskit_dynamics/models/operator_collections.py
@@ -20,6 +20,8 @@ from scipy.sparse import csr_matrix, issparse
 
 from qiskit import QiskitError
 from qiskit.quantum_info.operators.operator import Operator
+from qiskit_dynamics.arraylias import DYNAMICS_NUMPY_ALIAS as numpy_alias
+from qiskit_dynamics.arraylias.alias import _preferred_lib
 from qiskit_dynamics.array import Array, wrap
 from qiskit_dynamics.type_utils import to_array, to_csr, to_BCOO, vec_commutator, vec_dissipator
 
@@ -1357,7 +1359,7 @@ class BaseVectorizedLindbladCollection(BaseLindbladOperatorCollection, BaseOpera
     ) -> Array:
         """Concatenate hamiltonian and linblad signals."""
         if self._hamiltonian_operators is not None and self._dissipator_operators is not None:
-            return np.append(ham_sig_vals, dis_sig_vals, axis=-1)
+            return numpy_alias(like=_preferred_lib(ham_sig_vals, dis_sig_vals)).append(ham_sig_vals, dis_sig_vals, axis=-1)
         if self._hamiltonian_operators is not None and self._dissipator_operators is None:
             return ham_sig_vals
         if self._hamiltonian_operators is None and self._dissipator_operators is not None:

--- a/qiskit_dynamics/models/operator_collections.py
+++ b/qiskit_dynamics/models/operator_collections.py
@@ -21,7 +21,7 @@ from scipy.sparse import csr_matrix, issparse
 from qiskit import QiskitError
 from qiskit.quantum_info.operators.operator import Operator
 from qiskit_dynamics.arraylias import DYNAMICS_NUMPY_ALIAS as numpy_alias
-from qiskit_dynamics.arraylias.alias import _preferred_lib
+from qiskit_dynamics.arraylias.alias import _numpy_multi_dispatch
 from qiskit_dynamics.array import Array, wrap
 from qiskit_dynamics.type_utils import to_array, to_csr, to_BCOO, vec_commutator, vec_dissipator
 
@@ -1359,7 +1359,7 @@ class BaseVectorizedLindbladCollection(BaseLindbladOperatorCollection, BaseOpera
     ) -> Array:
         """Concatenate hamiltonian and linblad signals."""
         if self._hamiltonian_operators is not None and self._dissipator_operators is not None:
-            return numpy_alias(like=_preferred_lib(ham_sig_vals, dis_sig_vals)).append(ham_sig_vals, dis_sig_vals, axis=-1)
+            return _numpy_multi_dispatch(ham_sig_vals, dis_sig_vals, path="append", axis=-1)
         if self._hamiltonian_operators is not None and self._dissipator_operators is None:
             return ham_sig_vals
         if self._hamiltonian_operators is None and self._dissipator_operators is not None:

--- a/qiskit_dynamics/pulse/pulse_to_signals.py
+++ b/qiskit_dynamics/pulse/pulse_to_signals.py
@@ -38,6 +38,7 @@ from qiskit.pulse.exceptions import PulseError
 from qiskit.pulse.library import SymbolicPulse
 from qiskit import QiskitError
 
+from qiskit_dynamics import DYNAMICS_NUMPY as unp
 from qiskit_dynamics.array import Array
 from qiskit_dynamics.signals import DiscreteSignal
 
@@ -186,12 +187,10 @@ class InstructionToSignals:
 
                 # build sample array to append to signal
                 times = self._dt * (start_sample + np.arange(len(inst_samples)))
-                samples = inst_samples * np.exp(
-                    Array(
-                        2.0j * np.pi * frequency_shifts[chan] * times
-                        + 1.0j * phases[chan]
-                        + 2.0j * np.pi * phase_accumulations[chan]
-                    )
+                samples = inst_samples * unp.exp(
+                    2.0j * np.pi * frequency_shifts[chan] * times
+                    + 1.0j * phases[chan]
+                    + 2.0j * np.pi * phase_accumulations[chan]
                 )
                 signals[chan].add_samples(start_sample, samples)
 
@@ -202,7 +201,7 @@ class InstructionToSignals:
                 phases[chan] = inst.phase
 
             if isinstance(inst, ShiftFrequency):
-                frequency_shifts[chan] = frequency_shifts[chan] + Array(inst.frequency)
+                frequency_shifts[chan] = frequency_shifts[chan] + inst.frequency
                 phase_accumulations[chan] = (
                     phase_accumulations[chan] - inst.frequency * start_sample * self._dt
                 )

--- a/qiskit_dynamics/signals/signals.py
+++ b/qiskit_dynamics/signals/signals.py
@@ -28,6 +28,7 @@ from qiskit import QiskitError
 from qiskit_dynamics.arraylias import ArrayLike
 from qiskit_dynamics.arraylias import DYNAMICS_NUMPY_ALIAS as numpy_alias
 from qiskit_dynamics.arraylias import DYNAMICS_NUMPY as unp
+from qiskit_dynamics.arraylias.alias import _preferred_lib
 
 
 class Signal:
@@ -434,7 +435,7 @@ class DiscreteSignal(Signal):
                 new_samples, unp.repeat(zero_pad, start_sample - len(self.samples))
             )
 
-        new_samples = unp.append(new_samples, samples)
+        new_samples = numpy_alias(like=_preferred_lib(new_samples, samples)).append(new_samples, samples)
         self._padded_samples = unp.append(new_samples, zero_pad, axis=0)
 
     def __str__(self) -> str:

--- a/qiskit_dynamics/signals/signals.py
+++ b/qiskit_dynamics/signals/signals.py
@@ -28,7 +28,7 @@ from qiskit import QiskitError
 from qiskit_dynamics.arraylias import ArrayLike
 from qiskit_dynamics.arraylias import DYNAMICS_NUMPY_ALIAS as numpy_alias
 from qiskit_dynamics.arraylias import DYNAMICS_NUMPY as unp
-from qiskit_dynamics.arraylias.alias import _preferred_lib
+from qiskit_dynamics.arraylias.alias import _numpy_multi_dispatch
 
 
 class Signal:
@@ -435,7 +435,7 @@ class DiscreteSignal(Signal):
                 new_samples, unp.repeat(zero_pad, start_sample - len(self.samples))
             )
 
-        new_samples = numpy_alias(like=_preferred_lib(new_samples, samples)).append(new_samples, samples)
+        new_samples = _numpy_multi_dispatch(new_samples, samples, path="append")
         self._padded_samples = unp.append(new_samples, zero_pad, axis=0)
 
     def __str__(self) -> str:

--- a/qiskit_dynamics/signals/signals.py
+++ b/qiskit_dynamics/signals/signals.py
@@ -28,7 +28,7 @@ from qiskit import QiskitError
 from qiskit_dynamics.arraylias import ArrayLike
 from qiskit_dynamics.arraylias import DYNAMICS_NUMPY_ALIAS as numpy_alias
 from qiskit_dynamics.arraylias import DYNAMICS_NUMPY as unp
-from qiskit_dynamics.arraylias.alias import _numpy_multi_dispatch
+from qiskit_dynamics.arraylias.alias import _numpy_multi_dispatch, _preferred_lib
 
 
 class Signal:
@@ -308,7 +308,7 @@ class DiscreteSignal(Signal):
                 -1,
                 len(self.samples),
             )
-            return numpy_alias(like=idx).asarray(self._padded_samples)[idx]
+            return numpy_alias(like=_preferred_lib(self._padded_samples, idx)).asarray(self._padded_samples)[idx]
 
         Signal.__init__(self, envelope=envelope, carrier_freq=carrier_freq, phase=phase, name=name)
 

--- a/qiskit_dynamics/signals/transfer_functions.py
+++ b/qiskit_dynamics/signals/transfer_functions.py
@@ -23,6 +23,7 @@ import numpy as np
 
 from qiskit import QiskitError
 from qiskit_dynamics.arraylias import DYNAMICS_NUMPY as unp
+from qiskit_dynamics.arraylias.alias import _numpy_multi_dispatch
 
 from .signals import Signal, DiscreteSignal
 
@@ -118,10 +119,10 @@ class Convolution(BaseTransferFunction):
             # Perform a discrete time convolution.
             dt = signal.dt
             func_samples = unp.asarray([self._func(dt * i) for i in range(signal.duration)])
-            func_samples = func_samples / sum(func_samples)
+            func_samples = func_samples / unp.sum(func_samples)
             sig_samples = signal(dt * unp.arange(signal.duration))
 
-            convoluted_samples = list(unp.convolve(func_samples, sig_samples))
+            convoluted_samples = _numpy_multi_dispatch(func_samples, sig_samples, path="convolve")#unp.convolve(func_samples, sig_samples)
 
             return DiscreteSignal(dt, convoluted_samples, carrier_freq=0.0, phase=0.0)
         else:

--- a/test/dynamics/solvers/test_dyson_magnus_solvers.py
+++ b/test/dynamics/solvers/test_dyson_magnus_solvers.py
@@ -21,6 +21,7 @@ from qiskit import QiskitError
 
 from qiskit_dynamics import Signal, Solver, DysonSolver, MagnusSolver
 from qiskit_dynamics.array import Array
+from qiskit_dynamics import DYNAMICS_NUMPY as unp
 
 from qiskit_dynamics.solvers.perturbative_solvers.expansion_model import (
     _construct_DCT,
@@ -85,7 +86,7 @@ class Test_PerturbativeSolver(QiskitDynamicsTestCase):
         r = 0.2
 
         def gaussian(amp, sig, t0, t):
-            return amp * np.exp(-((t - t0) ** 2) / (2 * sig**2))
+            return amp * unp.exp(-((t - t0) ** 2) / (2 * sig**2))
 
         # specifications for generating envelope
         amp = 1.0  # amplitude
@@ -94,7 +95,7 @@ class Test_PerturbativeSolver(QiskitDynamicsTestCase):
         T = 7 * sig  # end of signal
 
         # Function to define gaussian envelope, using gaussian wave function
-        gaussian_envelope = lambda t: gaussian(Array(amp), Array(sig), Array(t0), Array(t)).data
+        gaussian_envelope = lambda t: gaussian(amp, sig, t0, t)
 
         obj.gauss_signal = Signal(gaussian_envelope, carrier_freq=5.0)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

First, a failing test for a perturbative solvers using JAX has been fixed by removing `Array` from the envelope function and instead using `unp`.

The rest of this PR fixes the remaining failures that all stem from the same issue (in both the pulse -> signal conversion code and in `operator_collections.py`). These were all the result of calling `unp.append(x, y)` with `x` being a `numpy` array and `y` being a JAX array. Due to `unp` dispatching on the first argument, this results in the evaluation of `np.append(x, y)`, which fails when `y` is a JAX tracer. 

The issue here is that what we fundamentally want here is multiple dispatch, but arraylias is single dispatch. To resolve this, I've added functions `_preferred_lib` and `_numpy_multi_dispatch` into `dynamics/arraylias/alias` that, given a list of arrays as arguments, will determine which array backend to use. Basically, for now it works as: if all arrays are of type `"numpy"` use numpy, but if _any_ are of type `"jax"` then JAX is used. The current logic presupposes that these are the _only_ two libraries. This will change later if more libraries are added.